### PR TITLE
Implement types.wrapElement/types.unwrapElement

### DIFF
--- a/can-jquery.js
+++ b/can-jquery.js
@@ -1,3 +1,4 @@
-export default function() {
-  return `This is the can-jquery plugin`;
-}
+var $ = require("jquery");
+var ns = require("can-util/namespace");
+
+module.exports = ns.$ = $;

--- a/can-jquery_test.js
+++ b/can-jquery_test.js
@@ -1,9 +1,16 @@
 import QUnit from 'steal-qunit';
-import plugin from './can-jquery';
+import Control from "can-control";
+import $ from "can-jquery/legacy";
 
-QUnit.module('can-jquery');
+QUnit.module('can-controls');
 
-QUnit.test('Initialized the plugin', function(){
-  QUnit.equal(typeof plugin, 'function');
-  QUnit.equal(plugin(), 'This is the can-jquery plugin');
+QUnit.test("this.element is jQuery wrapped", function(){
+	var MyThing = Control.extend({
+		init: function(){
+			QUnit.ok(this.element instanceof $, "it is jQuery wrapped");
+		}
+	});
+
+	var div = document.createElement("div");
+	new MyThing(div);
 });

--- a/legacy.js
+++ b/legacy.js
@@ -1,0 +1,10 @@
+var $ = module.exports = require("./can-jquery");
+var types = require("can-util/js/types/types");
+
+types.wrapElement = function(element){
+	return $(element);
+};
+
+types.unwrapElement = function(object){
+	return object ? object[0] : undefined;
+};

--- a/package.json
+++ b/package.json
@@ -52,9 +52,11 @@
   },
   "dependencies": {
     "can": "^2.3.16",
+    "can-util": "^3.0.0-pre.34",
     "jquery": "~2.2.1"
   },
   "devDependencies": {
+    "can-control": "^3.0.0-pre.6",
     "documentjs": "^0.4.2",
     "jshint": "^2.9.1",
     "cssify": "^0.6.0",


### PR DESCRIPTION
This elements `types.wrapElement` so that functionality like can-control
can have jQuery wrapped elements as is the case in CanJS < 3.

This functionality is opt-in by importing `can-jquery/legacy` rather
than just `can-jquery`.

Closes #2
