### PR TITLE
Ensure inserted/removed events fire when using jQuery

### DIFF
--- a/can-jquery.js
+++ b/can-jquery.js
@@ -1,4 +1,27 @@
 var $ = require("jquery");
 var ns = require("can-util/namespace");
+var domEvents = require("can-util/dom/events/events");
 
 module.exports = ns.$ = $;
+
+function setupSpecialEvent(eventName){
+	var handler = function(){
+		$(this).trigger(eventName);
+	};
+
+	$.event.special[eventName] = {
+		setup: function(){
+			domEvents.addEventListener.call(this, eventName, handler);
+		},
+		teardown: function(){
+			domEvents.removeEventListener.call(this, eventName, handler);
+		}
+	};
+}
+
+[
+	"inserted",
+	"removed",
+	"attributes"
+].forEach(setupSpecialEvent);
+

--- a/can-jquery_test.js
+++ b/can-jquery_test.js
@@ -1,6 +1,10 @@
-import QUnit from 'steal-qunit';
-import Control from "can-control";
-import $ from "can-jquery/legacy";
+var QUnit = require("steal-qunit");
+var Control = require("can-control");
+var $ = require("can-jquery/legacy");
+var mutate = require("can-util/dom/mutate/mutate");
+require("can-util/dom/events/inserted/inserted");
+require("can-util/dom/events/removed/removed");
+var MO = require("can-util/dom/mutation-observer/mutation-observer");
 
 QUnit.module('can-controls');
 
@@ -13,4 +17,78 @@ QUnit.test("this.element is jQuery wrapped", function(){
 
 	var div = document.createElement("div");
 	new MyThing(div);
+});
+
+QUnit.module("inserted/removed");
+
+QUnit.test("inserted is triggered", function(){
+	var $el = $("<div>");
+
+	$el.on("inserted", function(){
+		QUnit.ok(true, "inserted did fire");
+
+		QUnit.start();
+	});
+
+	mutate.appendChild.call($("#qunit-fixture")[0], $el[0]);
+
+	QUnit.stop();
+});
+
+QUnit.test("inserted is triggered without MutationObserver", function(){
+	var mo = MO();
+	MO(false);
+
+	var $el = $("<div>");
+
+	$el.on("inserted", function(){
+		QUnit.ok(true, "inserted did fire");
+
+		QUnit.start();
+
+		MO(mo);
+	});
+
+	mutate.appendChild.call($("#qunit-fixture")[0], $el[0]);
+
+	QUnit.stop();
+});
+
+QUnit.test("removed is triggered", function(){
+	var $el = $("<div>");
+
+	$el.on("removed", function(){
+		QUnit.ok(true, "removed did fire");
+
+		QUnit.start();
+	});
+
+	var fixture = $("#qunit-fixture")[0];
+
+	mutate.appendChild.call(fixture, $el[0]);
+	mutate.removeChild.call(fixture, $el[0]);
+
+	QUnit.stop();
+});
+
+QUnit.test("removed is triggered without MutationObserver", function(){
+	var mo = MO();
+	MO(false);
+
+	var $el = $("<div>");
+
+	$el.on("removed", function(){
+		QUnit.ok(true, "removed did fire");
+
+		QUnit.start();
+
+		MO(mo);
+	});
+
+	var fixture = $("#qunit-fixture")[0];
+
+	mutate.appendChild.call(fixture, $el[0]);
+	mutate.removeChild.call(fixture, $el[0]);
+
+	QUnit.stop();
 });


### PR DESCRIPTION
This ensures jQuery users can bind to the `inserted` and `removed`
events and that they work both with and without MutationObservers.

``` js
var $el = $("<div>");

$el.on("inserted", function(){
    // This was inserted
});

mutate.appendChild.call(document.body, $el[0]);
```

Closes #4
