### PR TITLE
Hook up jQuery and our own event systems

### DIFF
--- a/can-jquery.js
+++ b/can-jquery.js
@@ -4,18 +4,45 @@ var domEvents = require("can-util/dom/events/events");
 
 module.exports = ns.$ = $;
 
+var inSpecial = false;
+
+// Override addEventListener to listen to jQuery events as well.
+var addEventListener = domEvents.addEventListener;
+domEvents.addEventListener = function(event, callback){
+	if(!inSpecial) {
+		$(this).on(event, callback);
+	}
+	return addEventListener.apply(this, arguments);
+};
+
+var removeEventListener = domEvents.removeEventListener;
+domEvents.removeEventListener = function(event, callback){
+	if(!inSpecial) {
+		$(this).off(event, callback);
+	}
+	return removeEventListener.apply(this, arguments);
+};
+
+function withSpecial(callback){
+	return function(){
+		inSpecial = true;
+		callback.apply(this, arguments);
+		inSpecial = false;
+	};
+}
+
 function setupSpecialEvent(eventName){
 	var handler = function(){
 		$(this).trigger(eventName);
 	};
 
 	$.event.special[eventName] = {
-		setup: function(){
+		setup: withSpecial(function(){
 			domEvents.addEventListener.call(this, eventName, handler);
-		},
-		teardown: function(){
+		}),
+		teardown: withSpecial(function(){
 			domEvents.removeEventListener.call(this, eventName, handler);
-		}
+		})
 	};
 }
 
@@ -24,4 +51,3 @@ function setupSpecialEvent(eventName){
 	"removed",
 	"attributes"
 ].forEach(setupSpecialEvent);
-

--- a/can-jquery_test.js
+++ b/can-jquery_test.js
@@ -92,3 +92,18 @@ QUnit.test("removed is triggered without MutationObserver", function(){
 
 	QUnit.stop();
 });
+
+QUnit.module("custom jQuery events");
+
+QUnit.test("fire within controls", function(){
+	var MyControl = Control.extend({
+		"some-event": function(){
+			QUnit.ok(true, "some-event fired");
+		}
+	});
+
+	var div = $("<div>");
+	new MyControl(div);
+
+	div.trigger("some-event");
+});

--- a/package.json
+++ b/package.json
@@ -23,36 +23,15 @@
     "document": "documentjs",
     "develop": "done-serve --static --develop --port 8080"
   },
-  "main": "dist/cjs/can-jquery",
-  "browser": {
-    "transform": [
-      "cssify"
-    ]
-  },
-  "browserify": {
-    "transform": [
-      "cssify"
-    ]
-  },
+  "main": "can-jquery.js",
   "keywords": [
     "canjs"
   ],
   "system": {
-    "main": "can-jquery",
-    "configDependencies": [
-      "live-reload"
-    ],
-    "npmIgnore": [
-      "documentjs",
-      "testee",
-      "generator-donejs",
-      "donejs-cli",
-      "steal-tools"
-    ],
     "npmAlgorithm": "flat"
   },
   "dependencies": {
-    "can": "^2.3.16",
+    "can-event": "^3.0.0-pre.6",
     "can-util": "^3.0.0-pre.34",
     "jquery": "~2.2.1"
   },


### PR DESCRIPTION
This cross-binds our domEvents with jQuery's own event system so that
custom jQuery events can be listened to inside of controls and
responded to.

Closes #6
