### PR TITLE
Document can-jquery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,5 @@ node_modules
 # Users Environment Variables
 .lock-wscript
 
-docs/
 dist/
+doc/

--- a/can-jquery.md
+++ b/can-jquery.md
@@ -1,5 +1,1 @@
-@page can-jquery
 
-# can-jquery
-
-CanJS integrations for jQuery

--- a/docs/can-jquery.md
+++ b/docs/can-jquery.md
@@ -1,0 +1,65 @@
+@module {jQuery} can-jquery can-jquery
+@parent can-ecosystem
+
+@description Extensions to the event system so that can events and jQuery events are cross-bound.
+
+Importing can-jquery will return the [jQuery object](http://api.jquery.com/jquery/) and wire up the event system.
+
+```js
+var $ = require("can-jquery");
+
+var div = $("<div>");
+
+div.on("inserted", function(){
+	// it inserted!
+});
+
+$("body").append(div);
+```
+
+@body
+
+Using can-jquery causes the two event systems to be cross-bound. You can listen to special events within can using jQuery and you can listen to custom jQuery events within [can-control]s.
+
+## Listening to inserted/removed events
+
+Using can-jquery you can listen to the removed/inserted event on an element.
+
+```js
+var $ = require("can-jquery");
+
+var el = $("<div>");
+
+el.on("inserted", function(){
+	// The element was inserted.
+});
+
+$(document.body).append(el);
+```
+
+## Listening to jQuery events within Controls
+
+Inside a [can-control] you can listen to any custom jQuery events.
+
+```js
+var $ = require("can-jquery");
+var Control = require("can-control");
+
+var MyControl = Control.extend({
+	"names-added": function(el, ev, first, second, third){
+		// first is "Matthew"
+		// second is "David"
+		// third is "Brian"
+	}
+});
+
+var dom = $("<div><ul></ul></div>");
+
+new MyControl(dom);
+
+dom.find("ul").trigger("names-added", [
+	"Matthew",
+	"David",
+	"Brian"
+]);
+```

--- a/docs/legacy.md
+++ b/docs/legacy.md
@@ -1,0 +1,34 @@
+@module {jQuery} can-jquery/legacy can-jquery/legacy
+@parent can-jquery
+
+@description Enables legacy integrations between CanJS and jQuery.
+
+Importing can/jquery/legacy will return the [jQuery object](http://api.jquery.com/jquery/). It will also import [can-jquery] so that the event system hooks are set up.
+
+Additionally it will force element callbacks (such as those in [can-control]) to be jQuery wrapped.
+
+```js
+var $ = require("can-jquery/legacy");
+```
+
+@body
+
+Importing can-jquery/legacy will also bring in [can-jquery], but also has the side effect of enabling jQuery wrappers being applied to places such as [can-control]s and [can-stache-bindings.event] callbacks.
+
+***Note*** that simply importing can-jquery-legacy will enable this, so any [can-control]s expecting to receive the raw [HTMLElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement) will break.
+
+```js
+var $ = require("can-jquery/legacy");
+var Control = require("can-control");
+
+var MyControl = Control.extend({
+	"li click": function(el){
+		// `el` is jQuery wrapped!
+	}
+});
+
+var dom = $("<div><ul><li>First</li><li>Second</li></ul></div>");
+new MyControl(dom);
+
+dom.find("li:first").trigger("click");
+```

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "release:minor": "npm version minor && npm publish",
     "release:major": "npm version major && npm publish",
     "build": "node build.js",
-    "document": "documentjs",
+    "document": "bit-docs",
     "develop": "done-serve --static --develop --port 8080"
   },
   "main": "can-jquery.js",
@@ -31,13 +31,12 @@
     "npmAlgorithm": "flat"
   },
   "dependencies": {
-    "can-event": "^3.0.0-pre.6",
     "can-util": "^3.0.0-pre.34",
     "jquery": "~2.2.1"
   },
   "devDependencies": {
+    "bit-docs": "0.0.6",
     "can-control": "^3.0.0-pre.6",
-    "documentjs": "^0.4.2",
     "jshint": "^2.9.1",
     "cssify": "^0.6.0",
     "steal": "^0.15.0",
@@ -47,5 +46,26 @@
     "generator-donejs": "^0.9.0",
     "donejs-cli": "^0.8.0",
     "done-serve": "^0.1.0"
+  },
+  "bit-docs": {
+    "dependencies": {
+      "bit-docs-glob-finder": "^0.0.5",
+      "bit-docs-dev": "^0.0.3",
+      "bit-docs-js": "^0.0.3",
+      "bit-docs-generate-readme": "^0.0.8"
+    },
+    "glob": {
+      "pattern": "**/*.{js,md}",
+      "ignore": "node_modules/**/*"
+    },
+    "readme": {
+      "apis": [
+				{"can-jquery": [
+					"can-jquery/legacy"
+				]}
+			]
+    },
+    "parent": "can-jquery"
   }
+
 }

--- a/readme.md
+++ b/readme.md
@@ -4,54 +4,49 @@
 
 CanJS integrations for jQuery
 
-## Usage
+- <code>[__can-jquery__ jQuery](#can-jquery-jquery)</code>
+  - <code>[__can-jquery/legacy__ jQuery](#can-jquerylegacy-jquery)</code>
 
-### ES6 use
+## API
 
-With StealJS, you can import this module directly in a template that is autorendered:
+## can-jquery `{jQuery}`
 
-```js
-import plugin from 'can-jquery';
-```
-
-### CommonJS use
-
-Use `require` to load `can-jquery` and everything else
-needed to create a template that uses `can-jquery`:
+Extensions to the event system so that can events and jQuery events are cross-bound. 
+Importing can-jquery will return the [jQuery object](http://api.jquery.com/jquery/) and wire up the event system.
 
 ```js
-var plugin = require("can-jquery");
+var $ = require("can-jquery");
+
+var div = $("<div>");
+
+div.on("inserted", function(){
+	// it inserted!
+});
+
+$("body").append(div);
 ```
 
-## AMD use
 
-Configure the `can` and `jquery` paths and the `can-jquery` package:
 
-```html
-<script src="require.js"></script>
-<script>
-	require.config({
-	    paths: {
-	        "jquery": "node_modules/jquery/dist/jquery",
-	        "can": "node_modules/canjs/dist/amd/can"
-	    },
-	    packages: [{
-		    	name: 'can-jquery',
-		    	location: 'node_modules/can-jquery/dist/amd',
-		    	main: 'lib/can-jquery'
-	    }]
-	});
-	require(["main-amd"], function(){});
-</script>
+
+### <code>jQuery</code>
+
+### can-jquery/legacy `{jQuery}`
+
+Enables legacy integrations between CanJS and jQuery. 
+Importing can/jquery/legacy will return the [jQuery object](http://api.jquery.com/jquery/). It will also import [can-jquery](#can-jquery-jquery) so that the event system hooks are set up.
+
+Additionally it will force element callbacks (such as those in [can-control]) to be jQuery wrapped.
+
+```js
+var $ = require("can-jquery/legacy");
 ```
 
-### Standalone use
 
-Load the `global` version of the plugin:
 
-```html
-<script src='./node_modules/can-jquery/dist/global/can-jquery.js'></script>
-```
+
+#### <code>jQuery</code>
+
 
 ## Contributing
 


### PR DESCRIPTION
This adds documentation for usage of can-jquery, and adds the results to
the readme. On canjs.com the docs will show up under can-ecosystem.

Closes #9
