### PR TITLE
Handle inserted/removed firing when using jQuery's dommanip methods

### DIFF
--- a/can-jquery.js
+++ b/can-jquery.js
@@ -1,7 +1,15 @@
 var $ = require("jquery");
 var ns = require("can-util/namespace");
+var buildFragment = require("can-util/dom/fragment/fragment");
 var domEvents = require("can-util/dom/events/events");
 var domData = require("can-util/dom/data/data");
+var domDispatch = require("can-util/dom/dispatch/dispatch");
+var each = require("can-util/js/each/each");
+var getChildNodes = require("can-util/dom/child-nodes/child-nodes");
+var isArrayLike = require("can-util/js/is-array-like/is-array-like");
+var makeArray = require("can-util/js/make-array/make-array");
+var mutate = require("can-util/dom/mutate/mutate");
+var setImmediate = require("can-util/js/set-immediate/set-immediate");
 
 module.exports = ns.$ = $;
 
@@ -18,6 +26,14 @@ domEvents.addEventListener = function(event, callback){
 	if(!inSpecial) {
 		var handler = function(ev){
 			ev.eventArguments = slice.call(arguments, 1);
+
+			if(event === "removed") {
+				var self = this, args = arguments;
+				return setImmediate(function(){
+					return callback.apply(self, args);
+				});
+			}
+
 			return callback.apply(this, arguments);
 		};
 		domData.set.call(callback, EVENT_HANDLER, handler);
@@ -92,3 +108,92 @@ function setupSpecialEvent(eventName){
 	"removed",
 	"attributes"
 ].forEach(setupSpecialEvent);
+
+
+// Dom Mapip stuff
+var oldDomManip = $.fn.domManip,
+	cbIndex;
+
+// feature detect which domManip we are using
+$.fn.domManip = function () {
+	for (var i = 1; i < arguments.length; i++) {
+		if (typeof arguments[i] === 'function') {
+			cbIndex = i;
+			break;
+		}
+	}
+	return oldDomManip.apply(this, arguments);
+};
+$(document.createElement("div"))
+	.append(document.createElement("div"));
+
+if(cbIndex === undefined) {
+	$.fn.domManip = oldDomManip;
+	// we must manually overwrite
+	each(['after', 'prepend', 'before', 'append','replaceWith'], function (name) {
+		var original = $.fn[name];
+		$.fn[name] = function () {
+			var elems = [],
+				args = makeArray(arguments);
+
+			if (args[0] != null) {
+				// documentFragment
+				if (typeof args[0] === "string") {
+					args[0] = buildFragment(args[0]);
+				}
+				if (args[0].nodeType === 11) {
+					elems = getChildNodes(args[0]);
+				} else if( isArrayLike( args[0] ) ) {
+					elems = makeArray(args[0]);
+				} else {
+					elems = [args[0]];
+				}
+			}
+
+			var ret = original.apply(this, args);
+
+			mutate.inserted(elems);
+
+			return ret;
+		};
+	});
+} else {
+	// Older jQuery that supports domManip
+	
+
+	$.fn.domManip = (cbIndex === 2 ?
+		function (args, table, callback) {
+			return oldDomManip.call(this, args, table, function (elem) {
+				var elems;
+				if (elem.nodeType === 11) {
+					elems = makeArray( getChildNodes(elem) );
+				}
+				var ret = callback.apply(this, arguments);
+				mutate.inserted(elems ? elems : [elem]);
+				return ret;
+			});
+		} :
+		function (args, callback) {
+			return oldDomManip.call(this, args, function (elem) {
+				var elems;
+				if (elem.nodeType === 11) {
+					elems = makeArray( getChildNodes(elem) );
+				}
+				var ret = callback.apply(this, arguments);
+				mutate.inserted(elems ? elems : [elem]);
+				return ret;
+			});
+		});
+}
+
+// Memory safe destruction.
+var oldClean = $.cleanData;
+$.cleanData = function (elems){
+	$.each(elems, function(i, elem){
+		if(elem) {
+			domDispatch.call(elem, "removed", [], false);
+		}
+	});
+
+	oldClean(elems);
+};

--- a/can-jquery_test.js
+++ b/can-jquery_test.js
@@ -54,6 +54,27 @@ QUnit.test("inserted is triggered without MutationObserver", function(){
 	QUnit.stop();
 });
 
+QUnit.test("inserted is triggered without MutationObserver going through jQuery",
+					 function(){
+	var mo = MO();
+	MO(false);
+
+	var $el = $("<div>");
+
+	$el.on("inserted", function(){
+		QUnit.ok(true, "inserted did fire");
+
+		QUnit.start();
+
+		MO(mo);
+	});
+	
+	$("#qunit-fixture").append($el);
+
+	QUnit.stop();
+
+});
+
 QUnit.test("removed is triggered", function(){
 	var $el = $("<div>");
 
@@ -92,6 +113,30 @@ QUnit.test("removed is triggered without MutationObserver", function(){
 
 	QUnit.stop();
 });
+
+QUnit.test("removed is triggered without MutationObserver through jQuery", function(){
+	var mo = MO();
+	MO(false);
+
+	var $el = $("<div>");
+
+	$el.on("removed", function(){
+		QUnit.ok(true, "removed did fire");
+
+		QUnit.start();
+		MO(mo);
+	});
+
+	$el.on("inserted", function(){
+		$el.remove();
+	});
+
+	var fixture = $("#qunit-fixture");
+	fixture.append($el);
+
+	QUnit.stop();
+});
+
 
 QUnit.module("custom jQuery events");
 


### PR DESCRIPTION
This handles inserted/removed being fired when using jQuery's dom
manipulation methods and no MutationObservers are available.

Closes #11
