### PR TITLE
Unbind the event handler once it has been called

### DIFF
--- a/can-jquery.js
+++ b/can-jquery.js
@@ -23,9 +23,14 @@ var slice = Array.prototype.slice;
 // onto the event.
 var addEventListener = domEvents.addEventListener;
 domEvents.addEventListener = function(event, callback){
+	var handler;
 	if(!inSpecial) {
-		var handler = function(ev){
+		var element = this;
+		handler = function(ev){
 			ev.eventArguments = slice.call(arguments, 1);
+
+			// Remove the event handler to prevent the event from being called twice
+			domEvents.removeEventListener.call(element, event, handler);
 
 			if(event === "removed") {
 				var self = this, args = arguments;
@@ -40,7 +45,7 @@ domEvents.addEventListener = function(event, callback){
 
 		$(this).on(event, handler);
 	}
-	return addEventListener.apply(this, arguments);
+	return addEventListener.call(this, event, handler || callback);
 };
 
 var removeEventListener = domEvents.removeEventListener;

--- a/can-jquery_test.js
+++ b/can-jquery_test.js
@@ -5,6 +5,7 @@ var mutate = require("can-util/dom/mutate/mutate");
 require("can-util/dom/events/inserted/inserted");
 require("can-util/dom/events/removed/removed");
 var MO = require("can-util/dom/mutation-observer/mutation-observer");
+var domEvents = require("can-util/dom/events/events");
 
 QUnit.module('can-controls');
 
@@ -197,4 +198,18 @@ QUnit.test("receives data passed when delegating", function(){
 		"David",
 		"Brian"
 	]);
+});
+
+QUnit.module("Regular dom events");
+
+QUnit.test("Only fires once", function(){
+	QUnit.expect(1);
+
+	var el = $("<div>");
+
+	domEvents.addEventListener.call(el[0], "click", function(){
+		QUnit.ok(true);
+	});
+
+	el.trigger("click");
 });


### PR DESCRIPTION
This prevents double-events in the case where domEvents.addEventListener
is used to bind an event such as a lot of internal canjs code.
