### PR TITLE
Makes binding not remove handler after first dispatched

### DIFF
--- a/can-jquery.js
+++ b/can-jquery.js
@@ -51,12 +51,13 @@ domEvents.addEventListener = function(event, callback){
 var removeEventListener = domEvents.removeEventListener;
 domEvents.removeEventListener = function(event, callback){
 	if(!inSpecial) {
-		var eventHandler = domData.get.call(callback, EVENT_HANDLER);
-		if(eventHandler) {
-			domData.clean.call(callback, EVENT_HANDLER);
+		var eventHandler;
+		if(event === "removed") {
+			eventHandler = domData.get.call(callback, EVENT_HANDLER);
 		}
 
-		$(this).off(event, callback);
+		$(this).off(event, eventHandler || callback);
+		return;
 	}
 	return removeEventListener.apply(this, arguments);
 };

--- a/can-jquery_test.js
+++ b/can-jquery_test.js
@@ -71,7 +71,7 @@ QUnit.test("inserted is triggered without MutationObserver going through jQuery"
 
 		MO(mo);
 	});
-	
+
 	$("#qunit-fixture").append($el);
 
 	QUnit.stop();
@@ -225,4 +225,18 @@ QUnit.test("Gets an element's viewModel", function(){
 	domData.set.call(el[0], "viewModel", map);
 
 	QUnit.equal(el.viewModel(), map, "returns the map instance");
+});
+
+
+QUnit.test("multiple times fired (#21)", function(){
+	QUnit.expect(2);
+
+	var el = $("<div>");
+
+	domEvents.addEventListener.call(el[0], "click", function(){
+		QUnit.ok(true);
+	});
+
+	el.trigger("click");
+	el.trigger("click");
 });


### PR DESCRIPTION
fixes #21 

also makes `addDelegateListener` call straight to jquery.
