### PR TITLE
overwriting domEvents.dispatch to use jquery.trigger

### DIFF
--- a/can-jquery.js
+++ b/can-jquery.js
@@ -18,6 +18,13 @@ var inSpecial = false;
 var EVENT_HANDLER = "can-jquery.eventHandler";
 var slice = Array.prototype.slice;
 
+// Override dispatch to use $.trigger.
+// This is needed so that extra arguments can be used
+// when using domEvents.dispatch/domEvents.trigger.
+domEvents.dispatch = function(event, args) {
+	$(this).trigger(event, args);
+};
+
 // Override addEventListener to listen to jQuery events.
 // This is needed to add the arguments provided to $.trigger
 // onto the event.

--- a/can-jquery_test.js
+++ b/can-jquery_test.js
@@ -179,6 +179,29 @@ QUnit.test("receives data passed to $.trigger", function(){
 	]);
 });
 
+QUnit.test("receives data passed to $.trigger when using domEvents.dispatch", function() {
+	var MyControl = Control.extend({
+		"names-added": function(el, ev, first, second, third){
+			QUnit.equal(el[0].nodeName, "DIV", "element is the first arg");
+			QUnit.ok(ev instanceof $.Event, "second arg is a jQuery Event");
+
+			QUnit.equal(first, "Matthew");
+			QUnit.equal(second, "David");
+			QUnit.equal(third, "Brian");
+		}
+	});
+
+	var dom = $("<div></div>");
+
+	new MyControl(dom);
+
+	domEvents.dispatch.call(dom[0], "names-added", [
+		"Matthew",
+		"David",
+		"Brian"
+	]);
+});
+
 QUnit.test("receives data passed when delegating", function(){
 	var MyControl = Control.extend({
 		"ul	names-added": function(el, ev, first, second, third){


### PR DESCRIPTION
Second piece of https://github.com/canjs/canjs/issues/2527.
