### PR TITLE
Adding module for toggling legacy mode

### DIFF
--- a/can-jquery-stache-bindings_test.js
+++ b/can-jquery-stache-bindings_test.js
@@ -2,6 +2,9 @@ var QUnit = require('steal-qunit');
 var CanMap = require("can-map");
 var stache = require('can-stache');
 var canEvent = require('can-event');
+var $ = require('can-jquery/legacy');
+var enableLegacyMode = require("can-jquery/legacy-toggle").enable;
+var disableLegacyMode = require("can-jquery/legacy-toggle").disable;
 require('can-stache-bindings');
 
 var makeDocument = require('can-vdom/make-document/make-document');
@@ -20,6 +23,7 @@ var MUT_OBS = MUTATION_OBSERVER();
 function makeTest(name, doc, mutObs){
 	QUnit.module(name, {
 		setup: function () {
+			enableLegacyMode($);
 			DOCUMENT(doc);
 			MUTATION_OBSERVER(mutObs);
 
@@ -33,6 +37,7 @@ function makeTest(name, doc, mutObs){
 			}
 		},
 		teardown: function(){
+			disableLegacyMode();
 			if(doc !== document) {
 				doc.body.removeChild(this.fixture);
 			}

--- a/can-jquery_test.js
+++ b/can-jquery_test.js
@@ -1,6 +1,8 @@
 var QUnit = require("steal-qunit");
 var Control = require("can-control");
 var $ = require("can-jquery/legacy");
+var enableLegacyMode = require("can-jquery/legacy-toggle").enable;
+var disableLegacyMode = require("can-jquery/legacy-toggle").disable;
 var mutate = require("can-util/dom/mutate/mutate");
 require("can-util/dom/events/inserted/inserted");
 require("can-util/dom/events/removed/removed");
@@ -9,7 +11,14 @@ var domEvents = require("can-util/dom/events/events");
 var domData = require("can-util/dom/data/data");
 var Map = require("can-map");
 
-QUnit.module('can-controls');
+QUnit.module("can-jquery - can-controls", {
+	setup: function() {
+		enableLegacyMode($);
+	},
+	teardown: function() {
+		disableLegacyMode();
+	}
+});
 
 QUnit.test("this.element is jQuery wrapped", function(){
 	var MyThing = Control.extend({
@@ -22,7 +31,14 @@ QUnit.test("this.element is jQuery wrapped", function(){
 	new MyThing(div);
 });
 
-QUnit.module("inserted/removed");
+QUnit.module("can-jquery - inserted/removed", {
+	setup: function() {
+		enableLegacyMode($);
+	},
+	teardown: function() {
+		disableLegacyMode();
+	}
+});
 
 QUnit.test("inserted is triggered", function(){
 	var $el = $("<div>");
@@ -194,7 +210,14 @@ QUnit.test("removed should not use $.trigger", function(){
 	domEvents.dispatch.call($el[0], "removed", ["foo", "bar"]);
 });
 
-QUnit.module("custom jQuery events");
+QUnit.module("can-jquery - custom jQuery events", {
+	setup: function() {
+		enableLegacyMode($);
+	},
+	teardown: function() {
+		disableLegacyMode();
+	}
+});
 
 QUnit.test("fire within controls", function(){
 	var MyControl = Control.extend({
@@ -278,7 +301,14 @@ QUnit.test("receives data passed when delegating", function(){
 	]);
 });
 
-QUnit.module("Regular dom events");
+QUnit.module("can-jquery - Regular dom events", {
+	setup: function() {
+		enableLegacyMode($);
+	},
+	teardown: function() {
+		disableLegacyMode();
+	}
+});
 
 QUnit.test("Only fires once", function(){
 	QUnit.expect(1);
@@ -292,7 +322,14 @@ QUnit.test("Only fires once", function(){
 	el.trigger("click");
 });
 
-QUnit.module("$.fn.viewModel()");
+QUnit.module("can-jquery - $.fn.viewModel()", {
+	setup: function() {
+		enableLegacyMode($);
+	},
+	teardown: function() {
+		disableLegacyMode();
+	}
+});
 
 QUnit.test("Gets an element's viewModel", function(){
 	var el = $("<div>");

--- a/legacy-toggle.js
+++ b/legacy-toggle.js
@@ -1,0 +1,26 @@
+var types = require("can-util/js/types/types");
+var dev = require("can-util/js/dev/dev");
+
+function enable($) {
+	//!steal-remove-start
+	dev.warn("Using can-jquery/legacy will interfere with Components not expecting jQuery wrapped elements. Consider instead wrapping elements yourself in the init method.");
+	//!steal-remove-end
+
+	types.wrapElement = function(element){
+		return $(element);
+	};
+
+	types.unwrapElement = function(object){
+		return object ? object[0] : undefined;
+	};
+}
+
+function disable () {
+	delete types.wrapElement;
+	delete types.unwrapElement;
+}
+
+module.exports = {
+	enable: enable,
+	disable: disable
+};

--- a/legacy.js
+++ b/legacy.js
@@ -1,15 +1,4 @@
+var enableLegacyMode = require('./legacy-toggle').enable;
 var $ = module.exports = require("./can-jquery");
-var types = require("can-util/js/types/types");
-var dev = require("can-util/js/dev/dev");
 
-//!steal-remove-start
-dev.warn("Using can-jquery/legacy will interfere with Components not expecting jQuery wrapped elements. Consider instead wrapping elements yourself in the init method.");
-//!steal-remove-end
-
-types.wrapElement = function(element){
-	return $(element);
-};
-
-types.unwrapElement = function(object){
-	return object ? object[0] : undefined;
-};
+enableLegacyMode($);

--- a/legacy_test.js
+++ b/legacy_test.js
@@ -1,0 +1,23 @@
+var $ = require("can-jquery/legacy");
+var enable = require("./legacy-toggle").enable;
+var disable = require("./legacy-toggle").disable;
+var types = require("can-util/js/types/types");
+
+QUnit.module("can-jquery/legacy", {
+	setup: function() {
+		enable($);
+	},
+	teardown: function() {
+		disable();
+	}
+});
+
+QUnit.test("enable/disable", function(){
+	disable();
+	equal(typeof types.wrapElement, "undefined", "disable() should remove types.wrapElement by default");
+	equal(typeof types.unwrapElement, "undefined", "disable() should remove types.unwrapElement by default");
+
+	enable();
+	equal(typeof types.wrapElement, "function", "should add types.wrapElement by default");
+	equal(typeof types.unwrapElement, "function", "should add types.unwrapElement by default");
+});

--- a/test/test.js
+++ b/test/test.js
@@ -1,2 +1,3 @@
 import '../can-jquery_test';
 import '../can-jquery-stache-bindings_test';
+import '../legacy_test';


### PR DESCRIPTION
This way tests can clean up after themselves so that running the
can-jquery tests alongside tests for can-component, etc will
have predictable behavior.
