### PR TITLE
not setting up / tearing down event listeners on document fragments

### DIFF
--- a/can-jquery.js
+++ b/can-jquery.js
@@ -45,7 +45,7 @@ domEvents.addEventListener = function(event, callback){
 	// don't set up event listeners for document fragments
 	// since events will not be triggered and the handlers
 	// could lead to memory leaks
-	if (this.nodeName === '#document-fragment') {
+	if (this.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
 		return;
 	}
 
@@ -92,7 +92,7 @@ var removeEventListener = domEvents.removeEventListener;
 domEvents.removeEventListener = function(event, callback){
 	// event handlers are not set up on document fragments
 	// so they do not need to be removed
-	if (this.nodeName === '#document-fragment') {
+	if (this.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
 		return;
 	}
 

--- a/can-jquery_test.js
+++ b/can-jquery_test.js
@@ -424,3 +424,23 @@ QUnit.test("should clean up domData", function(){
 
 	QUnit.stop();
 });
+
+QUnit.test("should not trigger events on Document Fragments", function() {
+	expect(0);
+	var origOn = $.fn.on;
+	var origOff = $.fn.off;
+	$.fn.on = function() {
+		QUnit.ok(false, 'should not set up jQuery event listener');
+	};
+	$.fn.off = function() {
+		QUnit.ok(false, 'should not remove jQuery event listener');
+	};
+
+	var el = document.createDocumentFragment();
+
+	domEvents.addEventListener.call(el, "custom-event", function() { });
+	domEvents.removeEventListener.call(el, "custom-event", function() { });
+
+	$.fn.on = origOn;
+	$.fn.off = origOff;
+});

--- a/can-jquery_test.js
+++ b/can-jquery_test.js
@@ -406,25 +406,6 @@ QUnit.test("extra args to handler can be read using `%arguments`", function () {
 
 QUnit.module("can-jquery - addEventListener / removeEventListener");
 
-QUnit.test("should clean up domData", function(){
-	var $el = $("<div>");
-
-	domEvents.addEventListener.call($el[0], "removed", function(){
-		QUnit.ok(!domData.get.call($el[0], 'can-jquery.eventHandler'), 'domData is removed for element');
-		QUnit.start();
-	});
-
-	domEvents.addEventListener.call($el[0], "inserted", function(){
-		QUnit.ok(domData.get.call($el[0], 'can-jquery.eventHandler'), 'domData is set for element');
-		$el.remove();
-	});
-
-	var fixture = $("#qunit-fixture");
-	fixture.append($el);
-
-	QUnit.stop();
-});
-
 QUnit.test("should not trigger events on Document Fragments", function() {
 	expect(0);
 	var origOn = $.fn.on;
@@ -443,4 +424,25 @@ QUnit.test("should not trigger events on Document Fragments", function() {
 
 	$.fn.on = origOn;
 	$.fn.off = origOff;
+});
+
+QUnit.test("should call correct `removed` handler when one is removed", function() {
+	var $el = $("<div>");
+
+	var teardownOne = function() {
+		QUnit.ok(false, "removed event listener should not be called");
+	};
+
+	var teardownTwo = function() {
+		QUnit.ok(true, "event listener should be called");
+	};
+
+	domEvents.addEventListener.call($el[0], "removed", teardownOne);
+	domEvents.addEventListener.call($el[0], "removed", teardownTwo);
+
+	domEvents.removeEventListener.call($el[0], "removed", teardownOne);
+
+	var fixture = $("#qunit-fixture");
+	fixture.append($el);
+	$el.remove();
 });


### PR DESCRIPTION
Closes https://github.com/canjs/can-jquery/issues/66.
Also closes https://github.com/canjs/can-jquery/issues/71.