### PR TITLE
Call beforeremove evt before remove evt handler

### DIFF
--- a/can-jquery.js
+++ b/can-jquery.js
@@ -12,8 +12,6 @@ var setImmediate = require("can-util/js/set-immediate/set-immediate");
 var canViewModel = require("can-view-model");
 var MO = require("can-util/dom/mutation-observer/mutation-observer");
 var CIDMap = require("can-util/js/cid-map/cid-map");
-var assign = require("can-util/js/assign/assign");
-var isPlainObject = require("can-util/js/is-plain-object/is-plain-object");
 
 module.exports = ns.$ = $;
 
@@ -24,263 +22,247 @@ var slice = Array.prototype.slice;
 var removedEventHandlerMap = new CIDMap();
 
 if ($) {
+	// Override dispatch to use $.trigger.
+	// This is needed so that extra arguments can be used
+	// when using domEvents.dispatch/domEvents.trigger.
+	var domDispatch = domEvents.dispatch;
+	domEvents.dispatch = function(event, args) {
+		if (!specialEvents[event] && !nativeDispatchEvents[event]) {
 
-// Override dispatch to use $.trigger.
-// This is needed so that extra arguments can be used
-// when using domEvents.dispatch/domEvents.trigger.
-
-
-// import assign and isplainobject
-
-
-var domDispatch = domEvents.dispatch;
-domEvents.dispatch = function(event, args) {
-	if (!specialEvents[event] && !nativeDispatchEvents[event]) {
-		if(event && typeof event === "object" && !isPlainObject(event)) {
-		  event = assign({}, event);
-		}
-
-		// fix KeyboardEvent and other constructed events that do not have an own `type` property
-		// jquery.trigger will throw when on event.indexOf(...) if event.hasOwnProperty('type') fails
-		if (typeof event !== 'string' && !event.hasOwnProperty('type')) {
-			Object.defineProperty(event, 'type', {
-				value: event.type
-			});
-		}
-
-		$(this).trigger(event, args);
-	} else {
-		domDispatch.apply(this, arguments);
-	}
-};
-
-// Override addEventListener to listen to jQuery events.
-// This is needed to add the arguments provided to $.trigger
-// onto the event.
-var addEventListener = domEvents.addEventListener;
-domEvents.addEventListener = function(event, callback){
-	var handler;
-
-	// don't set up event listeners for document fragments
-	// since events will not be triggered and the handlers
-	// could lead to memory leaks
-	if (this.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
-		return;
-	}
-
-	if(!inSpecial) {
-
-		if(event === "removed") {
-			var element = this;
-
-			// overwrite `removed` event handlers
-			// to ensure they are dispatched async,
-			// pass arguments through correctly from $.trigger,
-			// and automatically unbind
-			handler = function(ev){
-				ev.eventArguments = slice.call(arguments, 1);
-
-				// Remove the event handler to prevent the event from being called twice
-				domEvents.removeEventListener.call(element, event, handler);
-
-				var self = this, args = arguments;
-				if (MO()) {
-					return callback.apply(self, args);
-				} else {
-					// if not using mutation observers, ensure event is dispatch async
-					return setImmediate(function(){
-						return callback.apply(self, args);
-					});
-				}
-			};
-
-			// add mapping of original handler to overwritten handler
-			// so that the correct handler can be unbound in removeEventListener
-			removedEventHandlerMap.set(callback, handler);
-		}
-
-		// if handler was created, set it up
-		// otherwise, just set up original callback
-		$(this).on(event, handler || callback);
-		return;
-	}
-	return addEventListener.call(this, event, handler || callback);
-};
-
-var removeEventListener = domEvents.removeEventListener;
-domEvents.removeEventListener = function(event, callback){
-	// event handlers are not set up on document fragments
-	// so they do not need to be removed
-	if (this.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
-		return;
-	}
-
-	if(!inSpecial) {
-		var handler;
-		if(event === "removed") {
-			// map callback back to overwritten handler
-			handler = removedEventHandlerMap.get(callback);
-			// remove mapping since handler is being removed
-			removedEventHandlerMap.delete(callback);
-		}
-
-		// if handler was found (set up above in addEventListener),
-		// remove it. otherwise, just remove original callback
-		$(this).off(event, handler || callback);
-		return;
-	}
-	return removeEventListener.apply(this, arguments);
-};
-
-// jQuery defines special event types for focus and blur
-// for use with event delegation. They do this because
-// focus and blur do not bubble.
-var delegateEventType = function delegateEventType(type) {
-	var typeMap = {
-		focus: 'focusin',
-		blur: 'focusout'
-	};
-	return typeMap[type] || type;
-};
-
-domEvents.addDelegateListener = function(type, selector, callback){
-	$(this).on(delegateEventType(type), selector, callback);
-};
-
-domEvents.removeDelegateListener = function(type, selector, callback){
-	$(this).off(delegateEventType(type), selector, callback);
-};
-
-var withSpecial = function withSpecial(callback){
-	return function(){
-		inSpecial = true;
-		callback.apply(this, arguments);
-		inSpecial = false;
-	};
-};
-
-var setupSpecialEvent = function setupSpecialEvent(eventName){
-	specialEvents[eventName] = true;
-
-	var handler = function(){
-		$(this).trigger(eventName);
-	};
-
-	$.event.special[eventName] = {
-		noBubble: true,
-		setup: withSpecial(function(){
-			// setup is called the first time a handler for `eventName`
-			// is set up for each element
-			domEvents.addEventListener.call(this, eventName, handler);
-		}),
-		teardown: withSpecial(function(){
-			// teardown is called after the last handler is removed for
-			// each element
-			domEvents.removeEventListener.call(this, eventName, handler);
-		})
-	};
-};
-
-[
-	"inserted",
-	"removed",
-	"attributes",
-	"beforeremove"
-].forEach(setupSpecialEvent);
-
-
-// Dom Mapip stuff
-var oldDomManip = $.fn.domManip,
-	cbIndex;
-
-// feature detect which domManip we are using
-$.fn.domManip = function () {
-	for (var i = 1; i < arguments.length; i++) {
-		if (typeof arguments[i] === 'function') {
-			cbIndex = i;
-			break;
-		}
-	}
-	return oldDomManip.apply(this, arguments);
-};
-$(document.createElement("div"))
-	.append(document.createElement("div"));
-
-if(cbIndex === undefined) {
-	$.fn.domManip = oldDomManip;
-	// we must manually overwrite
-	each(['after', 'prepend', 'before', 'append','replaceWith'], function (name) {
-		var original = $.fn[name];
-		$.fn[name] = function () {
-			var elems = [],
-				args = makeArray(arguments);
-
-			if (args[0] != null) {
-				// documentFragment
-				if (typeof args[0] === "string") {
-					args[0] = buildFragment(args[0]);
-				}
-				if (args[0].nodeType === 11) {
-					elems = getChildNodes(args[0]);
-				} else if( isArrayLike( args[0] ) ) {
-					elems = makeArray(args[0]);
-				} else {
-					elems = [args[0]];
-				}
+			// fix KeyboardEvent and other constructed events that do not have an own `type` property
+			// jquery.trigger will throw when on event.indexOf(...) if event.hasOwnProperty('type') fails
+			if (typeof event !== 'string' && !event.hasOwnProperty('type')) {
+				Object.defineProperty(event, 'type', {
+					value: event.type
+				});
 			}
 
-			var ret = original.apply(this, args);
-
-			mutate.inserted(elems);
-
-			return ret;
-		};
-	});
-} else {
-	// Older jQuery that supports domManip
-
-
-	$.fn.domManip = (cbIndex === 2 ?
-		function (args, table, callback) {
-			return oldDomManip.call(this, args, table, function (elem) {
-				var elems;
-				if (elem.nodeType === 11) {
-					elems = makeArray( getChildNodes(elem) );
-				}
-				var ret = callback.apply(this, arguments);
-				mutate.inserted(elems ? elems : [elem]);
-				return ret;
-			});
-		} :
-		function (args, callback) {
-			return oldDomManip.call(this, args, function (elem) {
-				var elems;
-				if (elem.nodeType === 11) {
-					elems = makeArray( getChildNodes(elem) );
-				}
-				var ret = callback.apply(this, arguments);
-				mutate.inserted(elems ? elems : [elem]);
-				return ret;
-			});
-		});
-}
-
-// Memory safe destruction.
-var oldClean = $.cleanData;
-$.cleanData = function (elems){
-	$.each(elems, function(i, elem){
-		if(elem) {
-			domDispatch.call(elem, "beforeremove", [], false);
-			domDispatch.call(elem, "removed", [], false);
+			$(this).trigger(event, args);
+		} else {
+			domDispatch.apply(this, arguments);
 		}
-	});
+	};
 
-	oldClean(elems);
-};
+	// Override addEventListener to listen to jQuery events.
+	// This is needed to add the arguments provided to $.trigger
+	// onto the event.
+	var addEventListener = domEvents.addEventListener;
+	domEvents.addEventListener = function(event, callback){
+		var handler;
+		// don't set up event listeners for document fragments
+		// since events will not be triggered and the handlers
+		// could lead to memory leaks
+		if (this.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
+			return;
+		}
 
-// $.fn.viewModel
-$.fn.viewModel = function(){
-	return canViewModel(this[0]);
-};
+		if(!inSpecial) {
+			if(event === "removed") {
+				var element = this;
 
+				// overwrite `removed` event handlers
+				// to ensure they are dispatched async,
+				// pass arguments through correctly from $.trigger,
+				// and automatically unbind
+				handler = function(ev){
+					ev.eventArguments = slice.call(arguments, 1);
+
+					// Remove the event handler to prevent the event from being called twice
+					domEvents.removeEventListener.call(element, event, handler);
+
+					var self = this, args = arguments;
+					if (MO()) {
+						return callback.apply(self, args);
+					} else {
+						// if not using mutation observers, ensure event is dispatch async
+						return setImmediate(function(){
+							return callback.apply(self, args);
+						});
+					}
+				};
+
+				// add mapping of original handler to overwritten handler
+				// so that the correct handler can be unbound in removeEventListener
+				removedEventHandlerMap.set(callback, handler);
+			}
+
+			// if handler was created, set it up
+			// otherwise, just set up original callback
+			$(this).on(event, handler || callback);
+			return;
+		}
+		return addEventListener.call(this, event, handler || callback);
+	};
+
+	var removeEventListener = domEvents.removeEventListener;
+	domEvents.removeEventListener = function(event, callback){
+		// event handlers are not set up on document fragments
+		// so they do not need to be removed
+		if (this.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
+			return;
+		}
+
+		if(!inSpecial) {
+			var handler;
+			if(event === "removed") {
+				// map callback back to overwritten handler
+				handler = removedEventHandlerMap.get(callback);
+				// remove mapping since handler is being removed
+				removedEventHandlerMap.delete(callback);
+			}
+
+			// if handler was found (set up above in addEventListener),
+			// remove it. otherwise, just remove original callback
+			$(this).off(event, handler || callback);
+			return;
+		}
+		return removeEventListener.apply(this, arguments);
+	};
+
+	// jQuery defines special event types for focus and blur
+	// for use with event delegation. They do this because
+	// focus and blur do not bubble.
+	var delegateEventType = function delegateEventType(type) {
+		var typeMap = {
+			focus: 'focusin',
+			blur: 'focusout'
+		};
+		return typeMap[type] || type;
+	};
+
+	domEvents.addDelegateListener = function(type, selector, callback){
+		$(this).on(delegateEventType(type), selector, callback);
+	};
+
+	domEvents.removeDelegateListener = function(type, selector, callback){
+		$(this).off(delegateEventType(type), selector, callback);
+	};
+
+	var withSpecial = function withSpecial(callback){
+		return function(){
+			inSpecial = true;
+			callback.apply(this, arguments);
+			inSpecial = false;
+		};
+	};
+
+	var setupSpecialEvent = function setupSpecialEvent(eventName){
+		specialEvents[eventName] = true;
+
+		var handler = function(){
+			$(this).trigger(eventName);
+		};
+
+		$.event.special[eventName] = {
+			noBubble: true,
+			setup: withSpecial(function(){
+				// setup is called the first time a handler for `eventName`
+				// is set up for each element
+				domEvents.addEventListener.call(this, eventName, handler);
+			}),
+			teardown: withSpecial(function(){
+				// teardown is called after the last handler is removed for
+				// each element
+				domEvents.removeEventListener.call(this, eventName, handler);
+			})
+		};
+	};
+
+	[
+		"inserted",
+		"removed",
+		"attributes",
+		"beforeremove"
+	].forEach(setupSpecialEvent);
+
+	// Dom Mapip stuff
+	var oldDomManip = $.fn.domManip,
+		cbIndex;
+
+	// feature detect which domManip we are using
+	$.fn.domManip = function () {
+		for (var i = 1; i < arguments.length; i++) {
+			if (typeof arguments[i] === 'function') {
+				cbIndex = i;
+				break;
+			}
+		}
+		return oldDomManip.apply(this, arguments);
+	};
+	$(document.createElement("div"))
+		.append(document.createElement("div"));
+
+	if(cbIndex === undefined) {
+		$.fn.domManip = oldDomManip;
+		// we must manually overwrite
+		each(['after', 'prepend', 'before', 'append','replaceWith'], function (name) {
+			var original = $.fn[name];
+			$.fn[name] = function () {
+				var elems = [],
+					args = makeArray(arguments);
+
+				if (args[0] != null) {
+					// documentFragment
+					if (typeof args[0] === "string") {
+						args[0] = buildFragment(args[0]);
+					}
+					if (args[0].nodeType === 11) {
+						elems = getChildNodes(args[0]);
+					} else if( isArrayLike( args[0] ) ) {
+						elems = makeArray(args[0]);
+					} else {
+						elems = [args[0]];
+					}
+				}
+
+				var ret = original.apply(this, args);
+				mutate.inserted(elems);
+
+				return ret;
+			};
+		});
+	} else {
+		// Older jQuery that supports domManip
+		$.fn.domManip = (cbIndex === 2 ?
+			function (args, table, callback) {
+				return oldDomManip.call(this, args, table, function (elem) {
+					var elems;
+					if (elem.nodeType === 11) {
+						elems = makeArray( getChildNodes(elem) );
+					}
+					var ret = callback.apply(this, arguments);
+					mutate.inserted(elems ? elems : [elem]);
+					return ret;
+				});
+			} :
+			function (args, callback) {
+				return oldDomManip.call(this, args, function (elem) {
+					var elems;
+					if (elem.nodeType === 11) {
+						elems = makeArray( getChildNodes(elem) );
+					}
+					var ret = callback.apply(this, arguments);
+					mutate.inserted(elems ? elems : [elem]);
+					return ret;
+				});
+			});
+	}
+
+	// Memory safe destruction.
+	var oldClean = $.cleanData;
+	$.cleanData = function (elems){
+		$.each(elems, function(i, elem){
+			if(elem) {
+				domDispatch.call(elem, "beforeremove", [], false);
+				domDispatch.call(elem, "removed", [], false);
+			}
+		});
+
+		oldClean(elems);
+	};
+
+	// $.fn.viewModel
+	$.fn.viewModel = function(){
+		return canViewModel(this[0]);
+	};
 }

--- a/can-jquery.js
+++ b/can-jquery.js
@@ -12,6 +12,8 @@ var setImmediate = require("can-util/js/set-immediate/set-immediate");
 var canViewModel = require("can-view-model");
 var MO = require("can-util/dom/mutation-observer/mutation-observer");
 var CIDMap = require("can-util/js/cid-map/cid-map");
+var assign = require("can-util/js/assign/assign");
+var isPlainObject = require("can-util/js/is-plain-object/is-plain-object");
 
 module.exports = ns.$ = $;
 
@@ -26,9 +28,17 @@ if ($) {
 // Override dispatch to use $.trigger.
 // This is needed so that extra arguments can be used
 // when using domEvents.dispatch/domEvents.trigger.
+
+
+// import assign and isplainobject
+
+
 var domDispatch = domEvents.dispatch;
 domEvents.dispatch = function(event, args) {
 	if (!specialEvents[event] && !nativeDispatchEvents[event]) {
+		if(event && typeof event === "object" && !isPlainObject(event)) {
+		  event = assign({}, event);
+		}
 		$(this).trigger(event, args);
 	} else {
 		domDispatch.apply(this, arguments);

--- a/can-jquery.js
+++ b/can-jquery.js
@@ -251,6 +251,7 @@ var oldClean = $.cleanData;
 $.cleanData = function (elems){
 	$.each(elems, function(i, elem){
 		if(elem) {
+			domDispatch.call(elem, "beforeremove", [], false);
 			domDispatch.call(elem, "removed", [], false);
 		}
 	});

--- a/can-jquery_test.js
+++ b/can-jquery_test.js
@@ -457,7 +457,7 @@ QUnit.test("should call beforeremove before removed", function() {
 	});
 
 	$el.on("removed", function(){
-		QUnit.ok(true, "beforeremove was called before removed");
+		QUnit.ok(calledBeforeRemove, "beforeremove was called before removed");
 	});
 
 	var fixture = $("#qunit-fixture")[0];

--- a/can-jquery_test.js
+++ b/can-jquery_test.js
@@ -61,7 +61,7 @@ QUnit.test("inserted is triggered", function(){
 QUnit.test("inserted does not bubble", function(){
 	expect(2);
 	var $div = $("<div>");
-	var $span = $("<span>");	
+	var $span = $("<span>");
 
 	$div.on("inserted", function(){
 		QUnit.ok(true, "inserted fired for div");
@@ -445,4 +445,23 @@ QUnit.test("should call correct `removed` handler when one is removed", function
 	var fixture = $("#qunit-fixture");
 	fixture.append($el);
 	$el.remove();
+});
+
+
+QUnit.test("should call beforeremove before removed", function() {
+	var calledBeforeRemove = false;
+	var $el = $("<div>");
+
+	$el.on("beforeremove", function(){
+		calledBeforeRemove = true;
+	});
+
+	$el.on("removed", function(){
+		QUnit.ok(true, "beforeremove was called before removed");
+	});
+
+	var fixture = $("#qunit-fixture")[0];
+
+	mutate.appendChild.call(fixture, $el[0]);
+	mutate.removeChild.call(fixture, $el[0]);
 });

--- a/can-jquery_test.js
+++ b/can-jquery_test.js
@@ -10,6 +10,7 @@ var domData = require("can-util/dom/data/data");
 var CanMap = require("can-map");
 var stache = require("can-stache");
 var canEvent = require("can-event");
+var Component = require('can-component');
 
 require("can-util/dom/events/inserted/inserted");
 require("can-util/dom/events/removed/removed");
@@ -449,19 +450,33 @@ QUnit.test("should call correct `removed` handler when one is removed", function
 
 
 QUnit.test("should call beforeremove before removed", function() {
-	var calledBeforeRemove = false;
-	var $el = $("<div>");
 
-	$el.on("beforeremove", function(){
-		calledBeforeRemove = true;
+	var beforeRemoveCalls = 0;
+
+	log = function(str) {
+		return function() {
+			beforeRemoveCalls++;
+			return console.log(str);
+		};
+	};
+
+	var WithBeforeRemove = Component.extend({
+	  tag: 'with-before-remove',
+	  view: stache('<content/>'),
+	  events: {
+	     '{element} beforeremove': log('{element} beforeremove'),
+	     ' beforeremove': log(' beforeremove'),
+	     beforeremove: log('beforeremove')
+	  }
 	});
 
-	$el.on("removed", function(){
-		QUnit.ok(calledBeforeRemove, "beforeremove was called before removed");
-	});
+	var tmpl = stache('<with-before-remove>Test</with-before-remove>');
 
-	var fixture = $("#qunit-fixture")[0];
+	var $playground = $('#qunit-fixture');
 
-	mutate.appendChild.call(fixture, $el[0]);
-	mutate.removeChild.call(fixture, $el[0]);
+	$playground.append(tmpl());
+	$playground.empty();
+
+	equal(beforeRemoveCalls, 3, 'calls beforeremove 3 times when component is removed from page');
+
 });

--- a/can-jquery_test.js
+++ b/can-jquery_test.js
@@ -453,20 +453,17 @@ QUnit.test("should call beforeremove before removed", function() {
 
 	var beforeRemoveCalls = 0;
 
-	log = function(str) {
-		return function() {
-			beforeRemoveCalls++;
-			return console.log(str);
-		};
+	var beforeRemoveCalled = function() {
+		beforeRemoveCalls++;
 	};
 
-	var WithBeforeRemove = Component.extend({
+	Component.extend({
 	  tag: 'with-before-remove',
 	  view: stache('<content/>'),
 	  events: {
-	     '{element} beforeremove': log('{element} beforeremove'),
-	     ' beforeremove': log(' beforeremove'),
-	     beforeremove: log('beforeremove')
+	     '{element} beforeremove': beforeRemoveCalled,
+	     ' beforeremove': beforeRemoveCalled,
+	     beforeremove: beforeRemoveCalled
 	  }
 	});
 


### PR DESCRIPTION
## Issue:
The `beforeremove` event is not being dispatched with can-jquery with can-component specifically.

## Solution:
Call the `beforeremove` event directly before the `remove` event handler is called.


---
**_Something else about this PR_**
It [includes code](https://github.com/canjs/can-jquery/pull/84/files#diff-c334c8dfc64444b5da4d2c3dcbd38e0cR39) that converts non-"plain object" events to "plain objects" by assigning all the properties of the passed event being dispatched to a new empty object and triggering that instead of the event obj that was passed in.  This was needed because the test for `can-util/dom/events/enter/` was not passing in the case of KeyboardEvents.