### PR TITLE
always packs the enter event to get order correctly working

### DIFF
--- a/can-jquery.js
+++ b/can-jquery.js
@@ -14,6 +14,10 @@ var MO = require("can-util/dom/mutation-observer/mutation-observer");
 var CIDMap = require("can-util/js/cid-map/cid-map");
 var assign = require("can-util/js/assign/assign");
 
+var addEnterEvent = require('can-event-dom-enter/compat');
+addEnterEvent(domEvents);
+
+
 module.exports = ns.$ = $;
 
 var specialEvents = {};
@@ -59,7 +63,7 @@ domEvents.addEventListener = function(event, callback){
 		return;
 	}
 
-	if(!inSpecial) {
+	if(!inSpecial && !domEvents._compatRegistry[event]) {
 
 		if(event === "removed") {
 			var element = this;


### PR DESCRIPTION
This makes `can-jquery` always load and mix in the enter event.  Any custom events need to be added by this point for everything to work correctly.

I'm not sure how to make it so the order doesn't matter.  

Done to get https://github.com/canjs/canjs/pull/3381 to pass.