### PR TITLE
Remove unused scripts + old bit-docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,7 @@
     "release:patch": "npm version patch && npm publish",
     "release:minor": "npm version minor && npm publish",
     "release:major": "npm version major && npm publish",
-    "build": "node build.js",
-    "document": "bit-docs",
-    "develop": "done-serve --static --develop --port 8080"
+    "build": "node build.js"
   },
   "main": "can-jquery.js",
   "keywords": [
@@ -49,27 +47,5 @@
     "steal-qunit": "^1.0.1",
     "steal-tools": "^1.2.0",
     "testee": "^0.6.1"
-  },
-  "bit-docs": {
-    "dependencies": {
-      "bit-docs-glob-finder": "^0.0.5",
-      "bit-docs-dev": "^0.0.3",
-      "bit-docs-js": "^0.0.3",
-      "bit-docs-generate-readme": "^0.0.8"
-    },
-    "glob": {
-      "pattern": "**/*.{js,md}",
-      "ignore": "node_modules/**/*"
-    },
-    "readme": {
-      "apis": [
-        {
-          "can-jquery": [
-            "can-jquery/legacy"
-          ]
-        }
-      ]
-    },
-    "parent": "can-jquery"
   }
 }


### PR DESCRIPTION
I accidentally re-added the `bit-docs`, this removes it and removes scripts we no longer use.