### PR TITLE
chore(package): update can-define to version 1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "can-component": "^3.3.4",
     "can-control": "^3.2.0",
-    "can-define": "^1.3.0",
+    "can-define": "^1.5.0",
     "can-list": "^3.2.1",
     "can-map": "^3.4.0",
     "can-stache": "^3.3.3",


### PR DESCRIPTION
Fixes #116