### PR TITLE
Fix dependency conflicts

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "can-event": "^3.7.5",
     "can-event-dom-enter": "^1.0.2",
     "can-globals": "^0.2.3",
-    "can-util": "^3.10.11",
+    "can-util": "^3.10.12",
     "can-view-model": "^3.4.0",
     "jquery": "2.x - 3.x"
   },
@@ -47,6 +47,7 @@
     "can-vdom": "^3.2.1",
     "detect-cyclic-packages": "^1.1.0",
     "jshint": "^2.9.1",
+    "qunitjs": "^2.4.0",
     "steal": "^1.5.15",
     "steal-qunit": "^1.0.1",
     "steal-tools": "^1.9.0",


### PR DESCRIPTION
The latest version of `can-util` uses `qunitjs@2.x` as a `devDependency`. Since `can-util`'s tests are run inside `can-jquery`'s tests, `qunitjs@2.x` is needed here.