### PR TITLE
Only set up custom events with jQuery if $ is defined

### DIFF
--- a/can-jquery.js
+++ b/can-jquery.js
@@ -16,7 +16,6 @@ var assign = require("can-util/js/assign/assign");
 
 var addEventJQuery = require('can-dom-events/helpers/add-event-jquery');
 var domEnter = require('can-event-dom-enter');
-addEventJQuery($, domEnter);
 
 module.exports = ns.$ = $;
 
@@ -27,6 +26,8 @@ var slice = Array.prototype.slice;
 var removedEventHandlerMap = new CIDMap();
 
 if ($) {
+	addEventJQuery($, domEnter);
+
 	// Override dispatch to use $.trigger.
 	// This is needed so that extra arguments can be used
 	// when using domEvents.dispatch/domEvents.trigger.


### PR DESCRIPTION
When this package’s tests are run in the main CanJS test suite, they are run both with and without jQuery, which caused an error to be thrown when jQuery wasn’t available.