### PR TITLE
Add support for the custom event delegation added to can-util

### DIFF
--- a/can-jquery.js
+++ b/can-jquery.js
@@ -137,6 +137,7 @@ if ($) {
 	var delegateEventType = function delegateEventType(type) {
 		var typeMap = {
 			focus: 'focusin',
+			enter: 'keyup',
 			blur: 'focusout'
 		};
 		return typeMap[type] || type;

--- a/can-jquery.js
+++ b/can-jquery.js
@@ -14,9 +14,9 @@ var getMutationObserver = require("can-globals/mutation-observer/mutation-observ
 var CIDMap = require("can-util/js/cid-map/cid-map");
 var assign = require("can-util/js/assign/assign");
 
-var addEventJQuery = require('can-dom-events/helpers/add-event-jquery');
-var domEnter = require('can-event-dom-enter');
-addEventJQuery($, domEnter);
+var addEnterEvent = require('can-event-dom-enter/compat');
+addEnterEvent(domEvents);
+
 
 module.exports = ns.$ = $;
 

--- a/can-jquery.js
+++ b/can-jquery.js
@@ -16,6 +16,7 @@ var assign = require("can-util/js/assign/assign");
 
 var addEventJQuery = require('can-dom-events/helpers/add-event-jquery');
 var domEnter = require('can-event-dom-enter');
+addEventJQuery($, domEnter);
 
 module.exports = ns.$ = $;
 
@@ -26,8 +27,6 @@ var slice = Array.prototype.slice;
 var removedEventHandlerMap = new CIDMap();
 
 if ($) {
-	addEventJQuery($, domEnter);
-
 	// Override dispatch to use $.trigger.
 	// This is needed so that extra arguments can be used
 	// when using domEvents.dispatch/domEvents.trigger.


### PR DESCRIPTION
This makes can-jquery compatible with the custom event delegation added to can-util 3.10.17: https://github.com/canjs/can-util/releases/tag/v3.10.17

This reverts https://github.com/canjs/can-jquery/pull/160 and my first attempt at this in https://github.com/canjs/can-jquery/pull/152

Closes https://github.com/canjs/can-jquery/issues/159